### PR TITLE
Add support for urls in addition to local paths on every platform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ultrastar-txt"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Robin Nehls <rust@manol.is>"]
 edition = "2018"
 description = "A library for parsing and generating Ultrastar TXT files"
@@ -23,6 +23,7 @@ chardet = {version = "0.2", optional = true}
 encoding = {version = "0.2", optional = true}
 error-chain = "0.12"
 serde = {version = "1", features = ["derive"], optional = true}
+url = "2.1.1"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ categories = ["parsing"]
 travis-ci = { repository = "man0lis/ultrastar-txt", branch = "master" }
 
 [features]
-default = ["file-support"]
+default = ["file-support", "url-support"]
 file-support = ["chardet", "encoding"]
+url-support = ["url"]
 
 [dependencies]
 regex = "1"
@@ -23,7 +24,7 @@ chardet = {version = "0.2", optional = true}
 encoding = {version = "0.2", optional = true}
 error-chain = "0.12"
 serde = {version = "1", features = ["derive"], optional = true}
-url = "2.1.1"
+url = {version="2.1.1", optional = true}
 
 [dev-dependencies]
 criterion = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate error_chain;
 #[macro_use]
 extern crate lazy_static;
 extern crate regex;
+#[cfg(feature = "url-support")]
 extern crate url;
 
 /// this module contains the generator

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate error_chain;
 #[macro_use]
 extern crate lazy_static;
 extern crate regex;
+extern crate url;
 
 /// this module contains the generator
 pub mod generator;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -2,7 +2,7 @@ extern crate chardet;
 extern crate encoding;
 
 use crate::parser::{parse_txt_header_str, parse_txt_lines_str};
-use crate::structs::TXTSong;
+use crate::structs::{TXTSong, Source};
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -59,23 +59,28 @@ fn read_file_to_string<P: AsRef<Path>>(p: P) -> Result<String> {
     Ok(file_content)
 }
 
-fn canonicalize_path<P: AsRef<Path>, B: AsRef<Path>>(
-    path: &Option<P>,
+fn canonicalize_path<B: AsRef<Path>>(
+    path: &Option<Source>,
     base_path: B,
-) -> Result<Option<PathBuf>> {
-    Ok(if let Some(ref path) = path {
-        let mut tmp_path = PathBuf::from(base_path.as_ref());
-        tmp_path.push(path);
-        let result = tmp_path
-            .canonicalize()
-            .chain_err(|| ErrorKind::CanonicalizationError)?;
-        Some(result)
+) -> Result<Option<Source>> {
+    Ok( if let Some(source) = path {
+        Some(match source {
+            Source::Remote(x) => Source::Remote(x),
+            Source::Local(x) => {
+                let mut tmp_path = PathBuf::from(base_path.as_ref());
+                tmp_path.push(x);
+                let result = tmp_path
+                    .canonicalize()
+                    .chain_err(|| ErrorKind::CanonicalizationError)?;
+                Source::Local(result)
+            }
+        })
     } else {
         None
     })
 }
 
-/// Takes path to a song file and returns TXTSong struct with canonicalized paths
+/// Takes path to a song file and returns TXTSong struct with canonicalized local sources
 ///
 /// # Arguments
 /// * path - the path to the song file to parse

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -65,6 +65,7 @@ fn canonicalize_path<B: AsRef<Path>>(
 ) -> Result<Option<Source>> {
     Ok( if let Some(source) = path {
         Some(match source {
+            #[cfg(feature = "url-support")]
             Source::Remote(x) => Source::Remote(x.to_owned()),
             Source::Local(x) => {
                 let mut tmp_path = PathBuf::from(base_path.as_ref());

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -65,7 +65,7 @@ fn canonicalize_path<B: AsRef<Path>>(
 ) -> Result<Option<Source>> {
     Ok( if let Some(source) = path {
         Some(match source {
-            Source::Remote(x) => Source::Remote(x),
+            Source::Remote(x) => Source::Remote(x.to_owned()),
             Source::Local(x) => {
                 let mut tmp_path = PathBuf::from(base_path.as_ref());
                 tmp_path.push(x);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,6 @@
-use crate::structs::{Header, Line, Note};
+use crate::structs::{Header, Line, Note, Source};
 use regex::Regex;
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 error_chain! {
     errors {
@@ -99,7 +98,7 @@ pub fn parse_txt_header_str(txt_str: &str) -> Result<Header> {
             }
             "MP3" => {
                 if opt_audio_path.is_none() {
-                    opt_audio_path = Some(PathBuf::from(value));
+                    opt_audio_path = Some(Source::parse(value));
                 } else {
                     bail!(ErrorKind::DuplicateHeader(line_count, "MP3"));
                 }
@@ -132,21 +131,21 @@ pub fn parse_txt_header_str(txt_str: &str) -> Result<Header> {
             }
             "COVER" => {
                 if opt_cover_path.is_none() {
-                    opt_cover_path = Some(PathBuf::from(value));
+                    opt_cover_path = Some(Source::parse(value));
                 } else {
                     bail!(ErrorKind::DuplicateHeader(line_count, "COVER"));
                 }
             }
             "BACKGROUND" => {
                 if opt_background_path.is_none() {
-                    opt_background_path = Some(PathBuf::from(value));
+                    opt_background_path = Some(Source::parse(value));
                 } else {
                     bail!(ErrorKind::DuplicateHeader(line_count, "BACKGROUND"));
                 }
             }
             "VIDEO" => {
                 if opt_video_path.is_none() {
-                    opt_video_path = Some(PathBuf::from(value));
+                    opt_video_path = Some(Source::parse(value));
                 } else {
                     bail!(ErrorKind::DuplicateHeader(line_count, "VIDEO"));
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -283,7 +283,7 @@ pub fn parse_txt_lines_str(txt_str: &str) -> Result<Vec<Line>> {
 
     let mut found_end_indicator = false;
     for (line, line_count) in txt_str.lines().zip(1..) {
-        let first_char = match line.chars().nth(0) {
+        let first_char = match line.chars().next() {
             Some(x) => x,
             None => bail!(ErrorKind::ParserFailure(line_count)),
         };

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::{PathBuf};
+#[cfg(feature = "url-support")]
 use url::Url;
 
 #[cfg(feature = "serde")]
@@ -20,6 +21,7 @@ error_chain! {
 #[derive(PartialEq, Clone, Debug)]
 pub enum Source {
     /// the Url to a (possibly remote) resource
+    #[cfg(feature = "url-support")]
     Remote(Url),
     /// the Path to a local file
     Local(PathBuf),
@@ -29,6 +31,7 @@ impl Source {
     /// convert the Url, respectively the path to a string
     pub fn to_str(&self) -> Option<&str> {
         match self {
+            #[cfg(feature = "url-support")]
             Source::Remote(url) => Some(url.as_str()),
             Source::Local(path) => path.to_str(),
         }
@@ -36,11 +39,13 @@ impl Source {
 
     /// attempt to parse a given string as an url or, if that fails, as a path
     pub fn parse(input_value: &str) -> Self {
-        if let Ok(x) = Url::parse(input_value) {
-            Source::Remote(x)
-        } else {
-            Source::Local(PathBuf::from(input_value))
-        }
+        #[cfg(feature = "url-support")]
+            {
+                if let Ok(x) = Url::parse(input_value) {
+                    return Source::Remote(x);
+                }
+            }
+        Source::Local(PathBuf::from(input_value))
     }
 }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -15,13 +15,18 @@ error_chain! {
     }
 }
 
+/// Describes the location of a file, either as a Url or a local path
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Clone, Debug)]
 pub enum Source {
+    /// the Url to a (possibly remote) resource
     Remote(Url),
-    Local(PathBuf)
+    /// the Path to a local file
+    Local(PathBuf),
 }
 
 impl Source {
+    /// convert the Url, respectively the path to a string
     pub fn to_str(&self) -> Option<&str> {
         match self {
             Source::Remote(url) => Some(url.as_str()),
@@ -29,7 +34,8 @@ impl Source {
         }
     }
 
-    pub fn parse(input_value: &str) -> Self { 
+    /// attempt to parse a given string as an url or, if that fails, as a path
+    pub fn parse(input_value: &str) -> Self {
         if let Ok(x) = Url::parse(input_value) {
             Source::Remote(x)
         } else {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,8 +1,42 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{PathBuf};
+use url::Url;
 
 #[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize};
+
+error_chain! {
+    errors {
+        #[doc="Path could not be processed"]
+        UnprocessablePath(line: u32, tag: &'static str) {
+            description("unprocessable path")
+            display("{} tag cannot be processed on line: {}", line, tag)
+        }
+    }
+}
+
+#[derive(PartialEq, Clone, Debug)]
+pub enum Source {
+    Remote(Url),
+    Local(PathBuf)
+}
+
+impl Source {
+    pub fn to_str(&self) -> Option<&str> {
+        match self {
+            Source::Remote(url) => Some(url.as_str()),
+            Source::Local(path) => path.to_str(),
+        }
+    }
+
+    pub fn parse(input_value: &str) -> Self { 
+        if let Ok(x) = Url::parse(input_value) {
+            Source::Remote(x)
+        } else {
+            Source::Local(PathBuf::from(input_value))
+        }
+    }
+}
 
 /// Describes the Header of an Ultrastar Song
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -16,17 +50,17 @@ pub struct Header {
     /// the beats per minute of the song
     pub bpm: f32,
     /// the path to the music file
-    pub audio_path: PathBuf,
+    pub audio_path: Source,
 
     // optional data from headers
     /// the gap between the start of the audio file and the first note in milliseconds
     pub gap: Option<f32>,
     /// the path to the cover file of the song
-    pub cover_path: Option<PathBuf>,
+    pub cover_path: Option<Source>,
     /// the path to the background file of the song
-    pub background_path: Option<PathBuf>,
+    pub background_path: Option<Source>,
     /// the path to the video file of the song
-    pub video_path: Option<PathBuf>,
+    pub video_path: Option<Source>,
     /// the time offset of the video file to the audio file
     pub video_gap: Option<f32>,
     /// the genre of the song


### PR DESCRIPTION
This adds support for files where instead of pointing to a local resource the e.g. audio path can point to a remote file or even a spotify url. (It is then of course up to the player to support playing from these resources)