### PR TITLE
add support for P1, P2 tags

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -66,7 +66,7 @@ pub fn parse_txt_header_str(txt_str: &str) -> Result<Header> {
     let mut opt_unknown: Option<HashMap<String, String>> = None;
 
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"#([A-Z3a-z]*):(.*)").unwrap();
+        static ref RE: Regex = Regex::new(r"#([A-Z1-3a-z]*):(.*)").unwrap();
     }
 
     for (line, line_count) in txt_str.lines().zip(1..) {


### PR DESCRIPTION
A lot of Duett files specify Names for P1 and P2 with the `#P1` and `#P2` header tag.
Previously if an essential header field was located below one of these tags it would fail.