### PR TITLE
add support for Rap and RapGolden notes

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -110,6 +110,20 @@ pub fn generate_song_txt(header: &Header, lines: &[Line]) -> Result<String> {
                     ref text,
                 } => song_txt_str
                     .push_str(format!("F {} {} {} {}\n", start, duration, pitch, text).as_ref()),
+                Note::Rap {
+                    start,
+                    duration,
+                    pitch,
+                    ref text,
+                } => song_txt_str
+                    .push_str(format!("R {} {} {} {}\n", start, duration, pitch, text).as_ref()),
+                Note::RapGolden {
+                    start,
+                    duration,
+                    pitch,
+                    ref text,
+                } => song_txt_str
+                    .push_str(format!("G {} {} {} {}\n", start, duration, pitch, text).as_ref()),
                 Note::PlayerChange { player } => {
                     song_txt_str.push_str(format!("P{}\n", player).as_ref())
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -359,6 +359,18 @@ pub fn parse_txt_lines_str(txt_str: &str) -> Result<Vec<Line>> {
                     pitch: note_pitch,
                     text: String::from(note_text),
                 },
+                "R" => Note::Rap {
+                    start: note_start,
+                    duration: note_duration,
+                    pitch: note_pitch,
+                    text: String::from(note_text),
+                },
+                "G" => Note::RapGolden {
+                    start: note_start,
+                    duration: note_duration,
+                    pitch: note_pitch,
+                    text: String::from(note_text),
+                },
                 _ => bail!(ErrorKind::UnknownNoteType(line_count)),
             };
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -152,6 +152,28 @@ pub enum Note {
         /// text or syllable of the note
         text: String,
     },
+    /// a rap note (pitch is ignored, normal points)
+    Rap {
+        /// start of the note
+        start: i32,
+        /// duration of the note
+        duration: i32,
+        /// pitch of the note (in semitones with C2 being 0)
+        pitch: i32, //pitch might not be needed but not including it might lose data from orig file
+        /// text or syllable of the note
+        text: String,
+    },
+    /// a golden rap note (pitch is ignored, 2x points)
+    RapGolden {
+        /// start of the note
+        start: i32,
+        /// duration of the note
+        duration: i32,
+        /// pitch of the note (in semitones with C2 being 0)
+        pitch: i32, //pitch might not be needed but not including it might lose data from orig file
+        /// text or syllable of the note
+        text: String,
+    },
     /// player change indicator for duet mode
     PlayerChange {
         /// player to change to
@@ -168,7 +190,9 @@ impl Note {
         match *self {
             Note::Regular { start, .. }
             | Note::Golden { start, .. }
-            | Note::Freestyle { start, .. } => Some(start),
+            | Note::Freestyle { start, .. }
+            | Note::Rap { start, .. }
+            | Note::RapGolden { start, .. } => Some(start),
             Note::PlayerChange { .. } => None,
         }
     }
@@ -178,7 +202,9 @@ impl Note {
         match *self {
             Note::Regular { duration, .. }
             | Note::Golden { duration, .. }
-            | Note::Freestyle { duration, .. } => Some(duration),
+            | Note::Freestyle { duration, .. }
+            | Note::Rap { duration, .. }
+            | Note::RapGolden { duration, .. } => Some(duration),
             Note::PlayerChange { .. } => None,
         }
     }
@@ -188,7 +214,9 @@ impl Note {
         match *self {
             Note::Regular { pitch, .. }
             | Note::Golden { pitch, .. }
-            | Note::Freestyle { pitch, .. } => Some(pitch),
+            | Note::Freestyle { pitch, .. }
+            | Note::Rap { pitch, .. }
+            | Note::RapGolden { pitch, .. } => Some(pitch),
             Note::PlayerChange { .. } => None,
         }
     }
@@ -198,7 +226,9 @@ impl Note {
         match *self {
             Note::Regular { ref text, .. }
             | Note::Golden { ref text, .. }
-            | Note::Freestyle { ref text, .. } => Some(text),
+            | Note::Freestyle { ref text, .. }
+            | Note::Rap { ref text, .. }
+            | Note::RapGolden { ref text, .. } => Some(text),
             Note::PlayerChange { .. } => None,
         }
     }
@@ -207,7 +237,7 @@ impl Note {
     pub fn player(&self) -> Option<i32> {
         match *self {
             Note::PlayerChange { player, .. } => Some(player),
-            Note::Regular { .. } | Note::Golden { .. } | Note::Freestyle { .. } => None,
+            Note::Regular { .. } | Note::Golden { .. } | Note::Freestyle { .. } | Note::Rap { .. } | Note::RapGolden { .. } => None,
         }
     }
 }

--- a/tests/txt.rs
+++ b/tests/txt.rs
@@ -29,6 +29,88 @@ fn simple_txt_lines() {
     assert_eq!(lines, parse_txt_lines_str(txt).unwrap());
 }
 
+
+
+#[test]
+fn rap_notes() {
+    let txt = include_str!("txts/rap_notes.txt");
+    let lines = vec![
+        Line {
+            start: 0,
+            rel: None,
+            notes: vec![
+                Note::Rap {
+                    start: 0,
+                    duration: 4,
+                    pitch: 59,
+                    text: String::from("Test "),
+                },
+                Note::Rap {
+                    start: 4,
+                    duration: 4,
+                    pitch: 59,
+                    text: String::from("I"),
+                },
+                Note::Rap {
+                    start: 8,
+                    duration: 4,
+                    pitch: 59,
+                    text: String::from("'m "),
+                },
+                Note::RapGolden {
+                    start: 12,
+                    duration: 4,
+                    pitch: 59,
+                    text: String::from("test"),
+                },
+                Note::Rap {
+                    start: 16,
+                    duration: 4,
+                    pitch: 59,
+                    text: String::from("ing."),
+                },
+            ],
+        },
+        Line {
+            start: 20,
+            rel: None,
+            notes: vec![
+                Note::Golden {
+                    start: 24,
+                    duration: 4,
+                    pitch: 59,
+                    text: String::from("Test "),
+                },
+                Note::Regular {
+                    start: 28,
+                    duration: 4,
+                    pitch: 59,
+                    text: String::from("I"),
+                },
+                Note::Regular {
+                    start: 32,
+                    duration: 4,
+                    pitch: 59,
+                    text: String::from("'m "),
+                },
+                Note::Freestyle {
+                    start: 36,
+                    duration: 4,
+                    pitch: 59,
+                    text: String::from("test"),
+                },
+                Note::Freestyle {
+                    start: 40,
+                    duration: 4,
+                    pitch: 59,
+                    text: String::from("ing."),
+                },
+            ],
+        },
+    ];
+    assert_eq!(lines, parse_txt_lines_str(txt).unwrap());
+}
+
 #[test]
 fn komma_in_float_number() {
     let txt = include_str!("txts/komma_in_float.txt");

--- a/tests/txts/rap_notes.txt
+++ b/tests/txts/rap_notes.txt
@@ -1,0 +1,17 @@
+#TITLE:Testsong
+#ARTIST:Testartist
+#MP3:Testfile.mp3
+#GAP:666
+#BPM:123
+R 0 4 59 Test 
+R 4 4 59 I
+R 8 4 59 'm 
+G 12 4 59 test
+R 16 4 59 ing.
+- 20
+* 24 4 59 Test 
+: 28 4 59 I
+: 32 4 59 'm 
+F 36 4 59 test
+F 40 4 59 ing.
+E


### PR DESCRIPTION
The [Ultrastar Worldparty](https://github.com/ultrastares/ultrastar-worldparty) Fork has introduced two new Note types: `Rap` and `RapGolden`, which differ from the existing Freestyle Notes by scoring them while ignoring the pitch.
(See [here](https://github.com/ultrastares/ultrastar-worldparty/blob/72feed9ea7a076099dea3d7b75068ae5f6ed5d38/src/base/USong.pas#L815), [here](https://github.com/ultrastares/ultrastar-worldparty/blob/72feed9ea7a076099dea3d7b75068ae5f6ed5d38/src/base/UMusic.pas#L72) and [here](https://github.com/ultrastares/ultrastar-worldparty/blob/72feed9ea7a076099dea3d7b75068ae5f6ed5d38/src/base/UNote.pas#L498).)

[Ultrastar Deluxe](https://github.com/UltraStar-Deluxe/USDX) seems to interpret those as regular notes, therefore I would like ot add support for them to ultrastar-txt.